### PR TITLE
Add a browser-only export for Web clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ It can also be used in NodeJS to connect to MeshCore Companion devices over TCP/
 npm install @liamcottle/meshcore.js
 ```
 
-## Simple Example
+## Simple Examples
 
-```
+### Enumerate Contacts (Node.js)
+
+```javascript
 import { TCPConnection, NodeJSSerialConnection } from "@liamcottle/meshcore.js";
 
 // serial connections are supported by "companion_radio_usb" firmware
@@ -51,6 +53,34 @@ connection.on("connected", async () => {
 
 // connect to meshcore device
 await connection.connect();
+```
+
+### Enumerate Contacts (Browser)
+
+```html
+<button id="connect-serial">Connect via Serial</button>
+
+<script type="module">
+import { WebBleConnection, WebSerialConnection } from "@liamcottle/meshcore.js";
+
+// wait until connected
+async function onConnected(connection) {
+
+    // we are now connected
+    console.log("connected!");
+
+    // log contacts
+    const contacts = await connection.getContacts();
+    for (const contact of contacts) {
+        console.log(`Contact: ${contact.advName}`);
+    }
+}
+
+document.getElementById("connect-serial").addEventListener("click", async () => {
+    const connection = await WebSerialConnection.open();
+    connection.on("connected", () => onConnected(connection));
+});
+</script>
 ```
 
 ## Examples

--- a/index.html
+++ b/index.html
@@ -195,10 +195,12 @@
 </div>
 
 <script type="module">
-    import Constants from "./src/constants.js";
-    import WebSerialConnection from "./src/connection/web_serial_connection.js";
-    import WebBleConnection from "./src/connection/web_ble_connection.js";
-    import BufferUtils from "./src/buffer_utils.js";
+    import {
+        Constants,
+        WebSerialConnection,
+        WebBleConnection,
+        BufferUtils,
+    } from "./src/browser.js";
     Vue.createApp({
         data() {
             return {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,15 @@
   "description": "",
   "main": "src/index.js",
   "type": "module",
+  "exports": {
+    ".": {
+      "browser": "./src/browser.js",
+      "import": "./src/index.js",
+      "default": "./src/index.js"
+    },
+    "./browser": "./src/browser.js",
+    "./node": "./src/node.js"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,0 +1,20 @@
+// Browser-only entrypoint – does NOT import Node-only transports (TCP, NodeJSSerial)
+import Connection from "./connection/connection.js";
+import WebBleConnection from "./connection/web_ble_connection.js";
+import WebSerialConnection from "./connection/web_serial_connection.js";
+import Constants from "./constants.js";
+import Advert from "./advert.js";
+import Packet from "./packet.js";
+import BufferUtils from "./buffer_utils.js";
+import CayenneLpp from "./cayenne_lpp.js";
+
+export {
+    Connection,
+    WebBleConnection,
+    WebSerialConnection,
+    Constants,
+    Advert,
+    Packet,
+    BufferUtils,
+    CayenneLpp,
+};

--- a/src/node.js
+++ b/src/node.js
@@ -1,0 +1,2 @@
+// Node-only entrypoint – re-exports everything including Node transports
+export * from "./index.js";


### PR DESCRIPTION
This package has a single export that includes both NodeJS and browser modules. When a web project imports this library, the bundler also imports the NodeJS-only modules, which generates a bunch of warnings, like this in vite:

```text
[plugin vite:resolve] Module net has been externalized for browser compatibility... 
[plugin vite:resolve] Module stream has been externalized for browser compatibility... 
...
```

We can clean this up by creating a special browser-only export. Bundlers like Vite and Webpack know to choose the 'browser' export in projects that are web-only (not NodeJS).

This change adds a 'browser' export and updates the documentation to use browser-only examples.

Clients don't need to change anything to benefit from this new export. The bundlers should just see the 'browser' export and use it automatically, but the warning spew will disappear.