### PR TITLE
Fix race condition in WebBleConnection

### DIFF
--- a/src/connection/web_ble_connection.js
+++ b/src/connection/web_ble_connection.js
@@ -9,7 +9,6 @@ class WebBleConnection extends Connection {
         this.gattServer = null;
         this.rxCharacteristic = null;
         this.txCharacteristic = null;
-        this.init();
     }
 
     static async open() {
@@ -36,8 +35,11 @@ class WebBleConnection extends Connection {
             return null;
         }
 
-        return new WebBleConnection(device);
+        // create connection and initialize it
+        const connection = new WebBleConnection(device);
+        await connection.init();
 
+        return connection;
     }
 
     async init() {


### PR DESCRIPTION
WebBleConnection's constructor calls init(), which is async. Constructors can't be async, so this means that callers who instantiate WebBleConnection can end up with it in an invalid state after construction if init() hasn't completed by the time the caller tries to access class members that depend on init.

I think the cleaner solution is to push the init() call to open(), which is async, so it can just await the results of init(), and the caller can trust that after calling open(), the connection is fully initialized.