### PR TITLE
Fix calls that treat lat/lng as uint32 instead of int32

### DIFF
--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -110,8 +110,8 @@ class Connection extends EventEmitter {
         data.writeBytes(outPath); // 64 bytes
         data.writeCString(advName, 32); // 32 bytes
         data.writeUInt32LE(lastAdvert);
-        data.writeUInt32LE(advLat);
-        data.writeUInt32LE(advLon);
+        data.writeInt32LE(advLat);
+        data.writeInt32LE(advLon);
         await this.sendToRadioFrame(data.toBytes());
     }
 
@@ -485,8 +485,8 @@ class Connection extends EventEmitter {
             outPath: bufferReader.readBytes(64),
             advName: bufferReader.readCString(32),
             lastAdvert: bufferReader.readUInt32LE(),
-            advLat: bufferReader.readUInt32LE(),
-            advLon: bufferReader.readUInt32LE(),
+            advLat: bufferReader.readInt32LE(),
+            advLon: bufferReader.readInt32LE(),
             lastMod: bufferReader.readUInt32LE(),
         });
     }
@@ -519,8 +519,8 @@ class Connection extends EventEmitter {
             outPath: bufferReader.readBytes(64),
             advName: bufferReader.readCString(32),
             lastAdvert: bufferReader.readUInt32LE(),
-            advLat: bufferReader.readUInt32LE(),
-            advLon: bufferReader.readUInt32LE(),
+            advLat: bufferReader.readInt32LE(),
+            advLon: bufferReader.readInt32LE(),
             lastMod: bufferReader.readUInt32LE(),
         });
     }


### PR DESCRIPTION
I have a device where the lat/lon was set using the iOS device to `34.4, -77.6`. The protocol says that lat/lon will be stored as a tuple of `int32 * 1e6`. However, the JS lib sometimes treats these as `uint32 * 1e6` ... which means that my `-77.6` is returned as `4217.3...`

This PR updates the few places where lat/lon are either written or read as a uint32.