### PR TITLE
feat: Generalize SetOtherParams, add per-field setters, sync requestTelemetry, and re-export constants

### DIFF
--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -3,6 +3,7 @@ import BufferReader from "../buffer_reader.js";
 import Constants from "../constants.js";
 import EventEmitter from "../events.js";
 import BufferUtils from "../buffer_utils.js";
+import CayenneLpp from "../cayenne_lpp.js";
 import Packet from "../packet.js";
 import RandomUtils from "../random_utils.js";
 
@@ -1826,6 +1827,38 @@ class Connection extends EventEmitter {
                 reject(e);
             }
         });
+    }
+
+    // High-level synchronous telemetry request.
+    // Sends REQ_TYPE_GET_TELEMETRY_DATA via sendBinaryReq, waits for the matching
+    // BinaryResponse push (correlated by tag), and decodes the response payload
+    // as Cayenne LPP. Mirrors python-meshcore's req_telemetry_sync.
+    //
+    // contactOrPublicKey: either a contact-like object with a `publicKey`
+    //                    property, or the raw 32-byte public key (Uint8Array
+    //                    or hex string).
+    // timeoutMs:         optional extra wait beyond the firmware's estimated
+    //                    timeout from the Sent response (default 10000ms).
+    async requestTelemetry(contactOrPublicKey, timeoutMs = 10000) {
+
+        // accept a contact object, a Uint8Array, or a hex string
+        let publicKey = contactOrPublicKey;
+        if(publicKey && typeof publicKey === "object" && publicKey.publicKey){
+            publicKey = publicKey.publicKey;
+        }
+        if(typeof publicKey === "string"){
+            publicKey = BufferUtils.hexToBytes(publicKey);
+        }
+
+        // request payload: just the request type byte (no params)
+        const requestData = new Uint8Array([Constants.BinaryRequestTypes.GetTelemetryData]);
+
+        // send + wait for tagged BinaryResponse push
+        const responseData = await this.sendBinaryRequest(publicKey, requestData, timeoutMs);
+
+        // decode Cayenne LPP payload
+        return CayenneLpp.parse(responseData);
+
     }
 
     sendBinaryRequest(contactPublicKey, requestCodeAndParams, extraTimeoutMillis = 1000) {

--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -461,10 +461,28 @@ class Connection extends EventEmitter {
     }
 
     onLoginSuccessPush(bufferReader) {
-        this.emit(Constants.PushCodes.LoginSuccess, {
-            reserved: bufferReader.readByte(), // reserved
-            pubKeyPrefix: bufferReader.readBytes(6), // 6 bytes of public key this login success is from
-        });
+        // MeshCore firmware >= 1.16 emits a 14-byte login-success frame that
+        // (after the leading push code) carries an is_admin flag, the remote's
+        // server timestamp, a granular ACL byte, and the remote's firmware
+        // version level. Older firmware emits only the legacy 8-byte frame
+        // (is_admin hard-coded to 0 by the firmware, no trailing fields), so the
+        // extended fields are parsed only when the bytes are actually present.
+        // See ripplebiz/MeshCore examples/companion_radio/MyMesh.cpp
+        // onContactResponse (RESP_SERVER_LOGIN_OK builder).
+        const isAdmin = bufferReader.readByte(); // byte 1: is_admin (0 on legacy fw)
+        const pubKeyPrefix = bufferReader.readBytes(6); // bytes 2-7: remote pubkey prefix
+        const response = {
+            reserved: isAdmin, // retained for backwards compatibility (this byte was previously treated as reserved)
+            isAdmin: isAdmin,
+            pubKeyPrefix: pubKeyPrefix,
+        };
+        // Trailing fields (firmware >= 1.16): [server_timestamp:u32LE][acl:u8][fw_ver_level:u8]
+        if(bufferReader.getRemainingBytesCount() >= 6){
+            response.serverTimestamp = bufferReader.readUInt32LE(); // bytes 8-11
+            response.aclPermissions = bufferReader.readByte(); // byte 12
+            response.firmwareVerLevel = bufferReader.readByte(); // byte 13
+        }
+        this.emit(Constants.PushCodes.LoginSuccess, response);
     }
 
     onStatusResponsePush(bufferReader) {

--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -331,10 +331,17 @@ class Connection extends EventEmitter {
         await this.sendToRadioFrame(data.toBytes());
     }
 
-    async sendCommandSetOtherParams(manualAddContacts) {
+    async sendCommandSetOtherParams(manualAddContacts, telemetryModeBase = 0, telemetryModeLoc = 0, telemetryModeEnv = 0, advLocPolicy = 0) {
         const data = new BufferWriter();
         data.writeByte(Constants.CommandCodes.SetOtherParams);
-        data.writeByte(manualAddContacts); // 0 or 1
+        data.writeByte(manualAddContacts ? 1 : 0);
+        // firmware packs the three telemetry modes into a single byte:
+        //   bits 0-1 = base, bits 2-3 = loc, bits 4-5 = env
+        const telemetryMode = (telemetryModeBase & 0b11)
+            | ((telemetryModeLoc & 0b11) << 2)
+            | ((telemetryModeEnv & 0b11) << 4);
+        data.writeByte(telemetryMode);
+        data.writeByte(advLocPolicy & 0xFF);
         await this.sendToRadioFrame(data.toBytes());
     }
 
@@ -697,20 +704,42 @@ class Connection extends EventEmitter {
     }
 
     onSelfInfoResponse(bufferReader) {
+        const type = bufferReader.readByte();
+        const txPower = bufferReader.readByte();
+        const maxTxPower = bufferReader.readByte();
+        const publicKey = bufferReader.readBytes(32);
+        const advLat = bufferReader.readInt32LE();
+        const advLon = bufferReader.readInt32LE();
+        const multiAcks = bufferReader.readByte();
+        const advLocPolicy = bufferReader.readByte();
+        const telemetryMode = bufferReader.readByte();
+        const manualAddContacts = bufferReader.readByte();
+        const radioFreq = bufferReader.readUInt32LE();
+        const radioBw = bufferReader.readUInt32LE();
+        const radioSf = bufferReader.readByte();
+        const radioCr = bufferReader.readByte();
+        const name = bufferReader.readString();
         this.emit(Constants.ResponseCodes.SelfInfo, {
-            type: bufferReader.readByte(),
-            txPower: bufferReader.readByte(),
-            maxTxPower: bufferReader.readByte(),
-            publicKey: bufferReader.readBytes(32),
-            advLat: bufferReader.readInt32LE(),
-            advLon: bufferReader.readInt32LE(),
-            reserved: bufferReader.readBytes(3),
-            manualAddContacts: bufferReader.readByte(),
-            radioFreq: bufferReader.readUInt32LE(),
-            radioBw: bufferReader.readUInt32LE(),
-            radioSf: bufferReader.readByte(),
-            radioCr: bufferReader.readByte(),
-            name: bufferReader.readString(),
+            type: type,
+            txPower: txPower,
+            maxTxPower: maxTxPower,
+            publicKey: publicKey,
+            advLat: advLat,
+            advLon: advLon,
+            // kept for backward compatibility — same 3 bytes, now also surfaced individually below
+            reserved: new Uint8Array([multiAcks, advLocPolicy, telemetryMode]),
+            multiAcks: multiAcks,
+            advLocPolicy: advLocPolicy,
+            telemetryMode: telemetryMode,
+            telemetryModeBase: telemetryMode & 0b11,
+            telemetryModeLoc: (telemetryMode >> 2) & 0b11,
+            telemetryModeEnv: (telemetryMode >> 4) & 0b11,
+            manualAddContacts: manualAddContacts,
+            radioFreq: radioFreq,
+            radioBw: radioBw,
+            radioSf: radioSf,
+            radioCr: radioCr,
+            name: name,
         });
     }
 
@@ -2344,7 +2373,22 @@ class Connection extends EventEmitter {
         });
     }
 
-    setOtherParams(manualAddContacts) {
+    // Accepts either the legacy signature `setOtherParams(manualAddContacts)`
+    // or an options object: `{ manualAddContacts, telemetryModeBase, telemetryModeLoc, telemetryModeEnv, advLocPolicy }`.
+    setOtherParams(manualAddContactsOrOpts, telemetryModeBase = 0, telemetryModeLoc = 0, telemetryModeEnv = 0, advLocPolicy = 0) {
+
+        let manualAddContacts;
+        if(typeof manualAddContactsOrOpts === "object" && manualAddContactsOrOpts !== null){
+            const opts = manualAddContactsOrOpts;
+            manualAddContacts = opts.manualAddContacts ?? 0;
+            telemetryModeBase = opts.telemetryModeBase ?? 0;
+            telemetryModeLoc = opts.telemetryModeLoc ?? 0;
+            telemetryModeEnv = opts.telemetryModeEnv ?? 0;
+            advLocPolicy = opts.advLocPolicy ?? 0;
+        } else {
+            manualAddContacts = manualAddContactsOrOpts;
+        }
+
         return new Promise(async (resolve, reject) => {
             try {
 
@@ -2367,7 +2411,7 @@ class Connection extends EventEmitter {
                 this.once(Constants.ResponseCodes.Err, onErr);
 
                 // set other params
-                await this.sendCommandSetOtherParams(manualAddContacts);
+                await this.sendCommandSetOtherParams(manualAddContacts, telemetryModeBase, telemetryModeLoc, telemetryModeEnv, advLocPolicy);
 
             } catch(e) {
                 reject(e);
@@ -2375,12 +2419,42 @@ class Connection extends EventEmitter {
         });
     }
 
+    // Read current SelfInfo and write back all fields with `patch` applied on top.
+    // This is the JS equivalent of python-meshcore's set_other_params_from_infos pattern.
+    async _setOtherParamsPatch(patch) {
+        const info = await this.getSelfInfo();
+        return await this.setOtherParams({
+            manualAddContacts: info.manualAddContacts,
+            telemetryModeBase: info.telemetryModeBase,
+            telemetryModeLoc: info.telemetryModeLoc,
+            telemetryModeEnv: info.telemetryModeEnv,
+            advLocPolicy: info.advLocPolicy,
+            ...patch,
+        });
+    }
+
+    async setTelemetryModeBase(mode) {
+        return await this._setOtherParamsPatch({ telemetryModeBase: mode });
+    }
+
+    async setTelemetryModeLoc(mode) {
+        return await this._setOtherParamsPatch({ telemetryModeLoc: mode });
+    }
+
+    async setTelemetryModeEnv(mode) {
+        return await this._setOtherParamsPatch({ telemetryModeEnv: mode });
+    }
+
+    async setAdvertLocPolicy(policy) {
+        return await this._setOtherParamsPatch({ advLocPolicy: policy });
+    }
+
     async setAutoAddContacts() {
-        return await this.setOtherParams(false);
+        return await this._setOtherParamsPatch({ manualAddContacts: 0 });
     }
 
     async setManualAddContacts() {
-        return await this.setOtherParams(true);
+        return await this._setOtherParamsPatch({ manualAddContacts: 1 });
     }
 
     // REQ_TYPE_GET_NEIGHBOURS from Repeater role

--- a/src/constants.js
+++ b/src/constants.js
@@ -137,6 +137,21 @@ class Constants {
         SignedPlain: 2,
     }
 
+    // Telemetry visibility mode for SetOtherParams (per-section: base / loc / env).
+    // Mirrors python-meshcore's TelemetryMode enum (2 bits per section).
+    static TelemetryMode = {
+        Disabled: 0,
+        AlwaysOn: 1,
+        OnRequestOnly: 2,
+        Reserved: 3,
+    }
+
+    // Advertisement location policy for SetOtherParams.
+    static AdvLocPolicy = {
+        None: 0,
+        Share: 1,
+    }
+
     static BinaryRequestTypes = {
         GetTelemetryData: 0x03, // #define REQ_TYPE_GET_TELEMETRY_DATA 0x03
         GetAvgMinMax: 0x04, // #define REQ_TYPE_GET_AVG_MIN_MAX 0x04

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,14 @@ import NodeJSSerialConnection from "./connection/nodejs_serial_connection.js";
 import WebSerialConnection from "./connection/web_serial_connection.js";
 import TCPConnection from "./connection/tcp_connection.js";
 import Constants from "./constants.js";
+
+// Frequently-referenced enums re-exported at the top level for convenience.
+const BinaryRequestTypes = Constants.BinaryRequestTypes;
+const TelemetryMode = Constants.TelemetryMode;
+const AdvLocPolicy = Constants.AdvLocPolicy;
+const CommandCodes = Constants.CommandCodes;
+const ResponseCodes = Constants.ResponseCodes;
+const PushCodes = Constants.PushCodes;
 import Advert from "./advert.js";
 import Packet from "./packet.js";
 import BufferUtils from "./buffer_utils.js";
@@ -20,6 +28,12 @@ export {
     WebSerialConnection,
     TCPConnection,
     Constants,
+    BinaryRequestTypes,
+    TelemetryMode,
+    AdvLocPolicy,
+    CommandCodes,
+    ResponseCodes,
+    PushCodes,
     Advert,
     Packet,
     BufferUtils,


### PR DESCRIPTION
## Summary

Three additions to support MeshMonitor's native JS integration, matching capabilities already present in python-meshcore. All follow existing code style and patterns.

## Changes

### 1. Generalize `sendCommandSetOtherParams` + per-field convenience setters

`sendCommandSetOtherParams` previously only carried `manualAddContacts`. The firmware's opcode 38 (`SetOtherParams`) actually carries the full field set:

- `manualAddContacts` (bool)
- `telemetryModeBase` (uint8, 2-bit)
- `telemetryModeLoc` (uint8, 2-bit)
- `telemetryModeEnv` (uint8, 2-bit)
- `advLocPolicy` (uint8)

This PR generalizes the method to pack all fields (telemetry modes into the single byte the firmware expects: `base | loc<<2 | env<<4`), matching python-meshcore's wire format.

New convenience methods using a read-modify-write pattern (AppStart read → patch one field → replay all):
- `setTelemetryModeBase(mode)`
- `setTelemetryModeLoc(mode)`
- `setTelemetryModeEnv(mode)`
- `setAdvertLocPolicy(policy)`

Also reworked `setAutoAddContacts` / `setManualAddContacts` to use the same safe read-modify-write pattern so they don't wipe sibling settings.

`onSelfInfoResponse` now decodes the 3 previously-reserved bytes into `multiAcks`, `advLocPolicy`, and `telemetryMode` (+ unpacked `telemetryModeBase/Loc/Env`). The `reserved` field is kept for backward compatibility.

New constants: `Constants.TelemetryMode` and `Constants.AdvLocPolicy` enums.

### 2. Sync `requestTelemetry` helper

`requestTelemetry(contactOrPublicKey, timeoutMs = 10000)` — sends `BinaryRequestTypes.GetTelemetryData` (0x03) via existing `sendBinaryRequest`, awaits the tagged `BinaryResponse` push, and returns parsed Cayenne LPP data. Accepts contact object, Uint8Array, or hex string.

This mirrors python-meshcore's `req_telemetry_sync()`.

### 3. Top-level constant re-exports

`TelemetryMode`, `BinaryRequestTypes`, `AdvLocPolicy`, `CommandCodes`, `ResponseCodes`, `PushCodes` are now also exported as named top-level exports from `src/index.js` for cleaner imports. `Constants` itself is still exported.

## Verification

- `node --check` on all modified files
- Runtime import smoke test
- Tested end-to-end in MeshMonitor against real MeshCore hardware (two Companion nodes over USB)