### PR TITLE
fix: send empty login password as zero bytes for read-only ACL

### DIFF
--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -231,7 +231,10 @@ class Connection extends EventEmitter {
         const data = new BufferWriter();
         data.writeByte(Constants.CommandCodes.SendLogin);
         data.writeBytes(publicKey); // 32 bytes - id of repeater or room server
-        data.writeString(password); // password is remainder of frame, max 15 characters
+        // Empty password = read-only ACL (0 bytes, matches official Android). Non-empty uses writeString.
+        if (password.length > 0) {
+            data.writeString(password); // password is remainder of frame, max 15 characters
+        }
         await this.sendToRadioFrame(data.toBytes());
     }
 


### PR DESCRIPTION
## Summary

- Empty guest/read-only login passwords are sent as a zero-byte remainder after the 32-byte public key (matches official MeshCore Android companion ACL).
- Non-empty passwords still use `writeString` as before.

## Context

Colorado-Mesh/mesh-client currently carries this as a pnpm patch against `@liamcottle/meshcore.js@1.13.0`. Upstreaming so other clients get correct read-only room/repeater login without a local patch.

## Test plan

- [ ] Login to a room server with a blank guest password (read-only ACL) and confirm `LoginSuccess`
- [ ] Login with a non-empty guest/admin password still works