### PR TITLE
fix: parse TraceData SNR count from path_sz flags

### DIFF
--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -494,15 +494,26 @@ class Connection extends EventEmitter {
     onTraceDataPush(bufferReader) {
         const reserved = bufferReader.readByte();
         const pathLen = bufferReader.readUInt8();
+        const flags = bufferReader.readUInt8();
+        const tag = bufferReader.readUInt32LE();
+        const authCode = bufferReader.readUInt32LE();
+        const path_sz = flags & 0x03;
+        const pathHashes = bufferReader.readBytes(pathLen);
+        // SNR count is pathLen >> path_sz (not pathLen); last SNR follows path SNRs.
+        const snrCount = pathLen >> path_sz;
+        const snrBytes = bufferReader.readBytes(snrCount + 1);
+        const pathSnrs = snrBytes.subarray(0, snrCount);
+        const lastSnr =
+            snrBytes.length > snrCount ? (snrBytes[snrCount] & 0xff) / 4 : 0;
         this.emit(Constants.PushCodes.TraceData, {
             reserved: reserved,
             pathLen: pathLen,
-            flags: bufferReader.readUInt8(),
-            tag: bufferReader.readUInt32LE(),
-            authCode: bufferReader.readUInt32LE(),
-            pathHashes: bufferReader.readBytes(pathLen),
-            pathSnrs: bufferReader.readBytes(pathLen),
-            lastSnr: bufferReader.readInt8() / 4,
+            flags: flags,
+            tag: tag,
+            authCode: authCode,
+            pathHashes: pathHashes,
+            pathSnrs: pathSnrs,
+            lastSnr: lastSnr,
         });
     }
 


### PR DESCRIPTION
## Summary

- Parse TraceData `flags`/`tag`/`authCode` before reading path hashes.
- Compute SNR count as `pathLen >> (flags & 0x03)` and read `snrCount + 1` bytes (path SNRs + last SNR).
- Avoids frame over-read on multi-hop traces where path hash bytes ≠ SNR count.

## Context

Colorado-Mesh/mesh-client currently carries this as a pnpm patch against `@liamcottle/meshcore.js@1.13.0`. Matches companion radio TraceData wire layout used by MeshCore firmware.

## Test plan

- [ ] Run a 0-hop ping/trace and confirm TraceData emits sane `pathSnrs` / `lastSnr`
- [ ] Run a multi-hop ping/trace and confirm path hash length and SNR count stay consistent (no truncated/overread fields)