### PR TITLE
feat: parse DeviceInfo v3+ fields and add setPathHashMode

### DIFF
--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -338,6 +338,14 @@ class Connection extends EventEmitter {
         await this.sendToRadioFrame(data.toBytes());
     }
 
+    async sendCommandSetPathHashMode(mode) {
+        const data = new BufferWriter();
+        data.writeByte(Constants.CommandCodes.SetPathHashMode); // CMD_SET_PATH_HASH_MODE (companion_radio v1.14+)
+        data.writeByte(0);
+        data.writeByte(mode);
+        await this.sendToRadioFrame(data.toBytes());
+    }
+
     onFrameReceived(frame) {
 
         // emit received frame
@@ -582,11 +590,30 @@ class Connection extends EventEmitter {
     }
 
     onDeviceInfoResponse(bufferReader) {
+        const firmwareVer = bufferReader.readInt8();
+        bufferReader.readBytes(6); // max contacts / channels (v3+)
+        const firmware_build_date = bufferReader.readCString(12);
+        const manufacturerModel = bufferReader.readCString(40);
+        const remaining = bufferReader.getRemainingBytesCount();
+        let firmwareVersion = null;
+        let clientRepeat = null;
+        let pathHashMode = null;
+        if (remaining >= 20) {
+            firmwareVersion = bufferReader.readCString(20);
+        }
+        if (bufferReader.getRemainingBytesCount() >= 1) {
+            clientRepeat = bufferReader.readByte();
+        }
+        if (bufferReader.getRemainingBytesCount() >= 1) {
+            pathHashMode = bufferReader.readByte();
+        }
         this.emit(Constants.ResponseCodes.DeviceInfo, {
-            firmwareVer: bufferReader.readInt8(),
-            reserved: bufferReader.readBytes(6), // reserved
-            firmware_build_date: bufferReader.readCString(12), // eg. "19 Feb 2025"
-            manufacturerModel: bufferReader.readString(), // remainder of frame
+            firmwareVer: firmwareVer,
+            firmware_build_date: firmware_build_date,
+            manufacturerModel: manufacturerModel,
+            firmwareVersion: firmwareVersion,
+            clientRepeat: clientRepeat,
+            pathHashMode: pathHashMode,
         });
     }
 
@@ -2368,6 +2395,37 @@ class Connection extends EventEmitter {
 
                 // set other params
                 await this.sendCommandSetOtherParams(manualAddContacts);
+
+            } catch(e) {
+                reject(e);
+            }
+        });
+    }
+
+    setPathHashMode(mode) {
+        return new Promise(async (resolve, reject) => {
+            try {
+
+                // resolve promise when we receive ok
+                const onOk = () => {
+                    this.off(Constants.ResponseCodes.Ok, onOk);
+                    this.off(Constants.ResponseCodes.Err, onErr);
+                    resolve();
+                }
+
+                // reject promise when we receive err
+                const onErr = () => {
+                    this.off(Constants.ResponseCodes.Ok, onOk);
+                    this.off(Constants.ResponseCodes.Err, onErr);
+                    reject();
+                }
+
+                // listen for events
+                this.once(Constants.ResponseCodes.Ok, onOk);
+                this.once(Constants.ResponseCodes.Err, onErr);
+
+                // set path hash mode
+                await this.sendCommandSetPathHashMode(mode);
 
             } catch(e) {
                 reject(e);

--- a/src/constants.js
+++ b/src/constants.js
@@ -67,6 +67,8 @@ class Constants {
 
         GetStats: 56,
 
+        SetPathHashMode: 61, // companion_radio v1.14+
+
         SendChannelData: 62,
     }
 


### PR DESCRIPTION
## Summary

- Parse companion DeviceInfo v3+ layout: fixed 40-byte `manufacturerModel`, optional 20-byte `firmwareVersion`, `clientRepeat`, and `pathHashMode`.
- Add `CommandCodes.SetPathHashMode` (61) plus `sendCommandSetPathHashMode` / `setPathHashMode` for companion_radio v1.14+.

## Context

Colorado-Mesh/mesh-client currently carries this as a pnpm patch against `@liamcottle/meshcore.js@1.13.0`. Newer companion firmware appends fields after the legacy DeviceInfo tail; reading the remainder as a single string truncates/misparses those fields.

## Test plan

- [ ] Query DeviceInfo on companion firmware that includes `firmwareVersion` / `pathHashMode` and confirm fields populate
- [ ] Call `setPathHashMode(mode)` and confirm Ok response on companion_radio v1.14+
- [ ] Older companions without the trailing fields still emit DeviceInfo without throwing