### PR TITLE
feat: handle LoginFail push frames

### DIFF
--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -400,6 +400,8 @@ class Connection extends EventEmitter {
             this.onRawDataPush(bufferReader);
         } else if(responseCode === Constants.PushCodes.LoginSuccess){
             this.onLoginSuccessPush(bufferReader);
+        } else if(responseCode === Constants.PushCodes.LoginFail){
+            this.onLoginFailPush(bufferReader);
         } else if(responseCode === Constants.PushCodes.StatusResponse){
             this.onStatusResponsePush(bufferReader);
         } else if(responseCode === Constants.PushCodes.LogRxData){
@@ -456,6 +458,13 @@ class Connection extends EventEmitter {
         this.emit(Constants.PushCodes.LoginSuccess, {
             reserved: bufferReader.readByte(), // reserved
             pubKeyPrefix: bufferReader.readBytes(6), // 6 bytes of public key this login success is from
+        });
+    }
+
+    onLoginFailPush(bufferReader) {
+        this.emit(Constants.PushCodes.LoginFail, {
+            reserved: bufferReader.readByte(), // reserved
+            pubKeyPrefix: bufferReader.readBytes(6), // 6 bytes of public key this login fail is from
         });
     }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -101,7 +101,7 @@ class Constants {
         MsgWaiting: 0x83,
         RawData: 0x84,
         LoginSuccess: 0x85,
-        LoginFail: 0x86, // not usable yet
+        LoginFail: 0x86,
         StatusResponse: 0x87,
         LogRxData: 0x88,
         TraceData: 0x89,


### PR DESCRIPTION
## Summary

- Dispatch `PushCodes.LoginFail` (0x86) to a new `onLoginFailPush` handler.
- Emit `{ reserved, pubKeyPrefix }` matching the LoginSuccess layout.
- Drop the \"not usable yet\" comment on `LoginFail` now that it is wired.

## Context

Colorado-Mesh/mesh-client currently carries this as a pnpm patch against `@liamcottle/meshcore.js@1.13.0`. Without this handler, wrong-password / ACL-denied logins only appear as unhandled frames.

## Test plan

- [ ] Attempt room login with a wrong password and confirm a `LoginFail` event with the expected pubkey prefix
- [ ] Successful login still emits `LoginSuccess` only