### PR TITLE
fix: stop readString at embedded NUL bytes

### DIFF
--- a/src/buffer_reader.js
+++ b/src/buffer_reader.js
@@ -24,7 +24,10 @@ class BufferReader {
     }
 
     readString() {
-        return new TextDecoder().decode(this.readRemainingBytes());
+        const bytes = this.readRemainingBytes();
+        const nullIdx = bytes.indexOf(0);
+        const slice = nullIdx >= 0 ? bytes.subarray(0, nullIdx) : bytes;
+        return new TextDecoder().decode(slice);
     }
 
     readCString(maxLength) {


### PR DESCRIPTION
## Summary

- `BufferReader.readString()` now truncates at the first embedded NUL when present, instead of decoding the entire remainder of the frame.
- Frames without a NUL continue to decode the full remainder.

## Context

Colorado-Mesh/mesh-client currently carries this as a pnpm patch against `@liamcottle/meshcore.js@1.13.0`. Companion DeviceInfo and similar frames can append typed fields after a formerly remainder-string field; without NUL truncation, `readString()` returns garbage including those trailing bytes.

## Test plan

- [ ] Decode a frame whose remainder string contains a trailing NUL + extra bytes and confirm only the prefix is returned
- [ ] Decode a frame with no NUL and confirm full remainder decoding is unchanged