### PR TITLE
Parse V3 received-message frames instead of dropping them

### DIFF
--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -358,8 +358,12 @@ class Connection extends EventEmitter {
             this.onNoMoreMessagesResponse(bufferReader);
         } else if(responseCode === Constants.ResponseCodes.ContactMsgRecv){
             this.onContactMsgRecvResponse(bufferReader);
+        } else if(responseCode === Constants.ResponseCodes.ContactMsgRecvV3){
+            this.onContactMsgRecvResponse(bufferReader, true);
         } else if(responseCode === Constants.ResponseCodes.ChannelMsgRecv){
             this.onChannelMsgRecvResponse(bufferReader);
+        } else if(responseCode === Constants.ResponseCodes.ChannelMsgRecvV3){
+            this.onChannelMsgRecvResponse(bufferReader, true);
         } else if(responseCode === Constants.ResponseCodes.ContactsStart){
             this.onContactsStartResponse(bufferReader);
         } else if(responseCode === Constants.ResponseCodes.Contact){
@@ -726,23 +730,46 @@ class Connection extends EventEmitter {
         });
     }
 
-    onContactMsgRecvResponse(bufferReader) {
+    // The firmware emits the V3 variant of a received-message frame when the last
+    // app to send CMD_DEVICE_QUERY declared protocol version >= 3. That state is
+    // global to the device, is only reset on reboot, and the frame layout is baked
+    // in when the message is queued - so a V3 frame can reach us even though we
+    // declare version 1 ourselves. Read the extra header when present, so those
+    // messages are delivered instead of silently dropped as an unhandled frame.
+    readMsgRecvSnr(bufferReader, isV3) {
+
+        if(!isV3){
+            return null;
+        }
+
+        const snr = bufferReader.readInt8() / 4;
+        bufferReader.readBytes(2); // reserved
+
+        return snr;
+
+    }
+
+    onContactMsgRecvResponse(bufferReader, isV3 = false) {
+        const snr = this.readMsgRecvSnr(bufferReader, isV3);
         this.emit(Constants.ResponseCodes.ContactMsgRecv, {
             pubKeyPrefix: bufferReader.readBytes(6),
             pathLen: bufferReader.readByte(),
             txtType: bufferReader.readByte(),
             senderTimestamp: bufferReader.readUInt32LE(),
             text: bufferReader.readString(),
+            snr: snr, // null unless the device sent the V3 frame
         });
     }
 
-    onChannelMsgRecvResponse(bufferReader) {
+    onChannelMsgRecvResponse(bufferReader, isV3 = false) {
+        const snr = this.readMsgRecvSnr(bufferReader, isV3);
         this.emit(Constants.ResponseCodes.ChannelMsgRecv, {
             channelIdx: bufferReader.readInt8(), // reserved (0 for now, ie. 'public')
             pathLen: bufferReader.readByte(), // 0xFF if was sent direct, otherwise hop count for flood-mode
             txtType: bufferReader.readByte(),
             senderTimestamp: bufferReader.readUInt32LE(),
             text: bufferReader.readString(),
+            snr: snr, // null unless the device sent the V3 frame
         });
     }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -87,6 +87,8 @@ class Constants {
         DeviceInfo: 13,
         PrivateKey: 14,
         Disabled: 15,
+        ContactMsgRecvV3: 16, // same as ContactMsgRecv, prefixed with snr + 2 reserved bytes
+        ChannelMsgRecvV3: 17, // same as ChannelMsgRecv, prefixed with snr + 2 reserved bytes
         ChannelInfo: 18,
         SignStart: 19,
         Signature: 20,


### PR DESCRIPTION
## Problem

On current companion firmware, received-message frames can arrive in their V3 form:

```
RESP_CODE_CONTACT_MSG_RECV_V3 16   // MyMesh.cpp:87
RESP_CODE_CHANNEL_MSG_RECV_V3 17   // MyMesh.cpp:88
```

These carry the same payload as codes 7/8, prefixed with an SNR byte and two reserved bytes. This library doesn't
know either code, so they fall through to `unhandled frame: code=17` in `onFrameReceived()` and the message is
lost.

At first glance this shouldn't affect us — the firmware only emits V3 when `app_target_ver >= 3`, and
`onConnected()` sends `CMD_DEVICE_QUERY` with `SupportedCompanionProtocolVersion = 1`. But:

- `app_target_ver` is set by whichever app last sent `CMD_DEVICE_QUERY` and is global to the device
  (`MyMesh.cpp:1009`);
- it is reset only in the `MyMesh` constructor (`MyMesh.cpp:861`), i.e. at boot — not when a client disconnects;
- the frame layout is chosen when the message is **queued** (`MyMesh.cpp:432`, `:545`), then stored in the offline
  queue and replayed verbatim later.

So a phone app negotiating version 3 once is enough to make the node hand V3 frames to a version-1 client for
everything queued from then until reboot. Captured on a serial connection from a bot that declares version 1:

```
unhandled frame: code=17 [ 17, 218, 0, 0, 0, 14, 0, 61, 77, 116, 106, 73, 110, 51, 104, 99, 100, 58, 32, 84, 101, 115, 116 ]
                     ^^   ^^^  ^^^^  ^^  ^^  ^  ^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                    0x11  SNR   rsv  ch  len  t     timestamp                "In3hcd: Test"
```

Losing these silently is worse than it looks: `syncNextMessage()` resolves only on one of the four frames it
listens for, so a dropped V3 frame mid-sync leaves that promise pending forever and the client stops receiving
anything at all.

## Change

Parse both layouts and emit them on the existing `ContactMsgRecv` / `ChannelMsgRecv` events, with the decoded
`snr` added to the payload (`null` when the device sent the V1 layout). Nothing downstream has to change —
`syncNextMessage()` and existing consumers keep working, and clients that want SNR now get it.

## Verification

Both frames above (the captured V3 one and the same message hand-encoded as V1) decode identically:

```
V3: { channelIdx: 0, pathLen: 14, txtType: 0, senderTimestamp: 1786006845, text: 'In3hcd: Test', snr: -9.5 }
V1: { channelIdx: 0, pathLen: 14, txtType: 0, senderTimestamp: 1786006845, text: 'In3hcd: Test', snr: null }
```

SNR decoding follows the firmware's `(int8_t)(pkt->getSNR() * 4)`, i.e. signed byte ÷ 4.
